### PR TITLE
Honor NO_COLOR in clnkr TUI

### DIFF
--- a/cmd/clnkr/chat.go
+++ b/cmd/clnkr/chat.go
@@ -286,15 +286,13 @@ func (c *chatModel) updateViewport() {
 
 // writeRendered renders markdown content through glamour and appends to committed content.
 func (c *chatModel) writeRendered(content string) {
-	rendered := renderMarkdown(content, c.viewport.Width())
+	rendered := renderMarkdown(content, c.viewport.Width(), c.styles.NoColor)
 	c.content.WriteString(rendered)
 }
 
 func (c *chatModel) resize(width, height int) {
 	c.viewport.SetWidth(width)
 	c.viewport.SetHeight(height)
-	// Reset renderer on width change so glamour re-wraps
-	renderer = nil
 }
 
 // summarizeCommand returns a short display form of a command.

--- a/cmd/clnkr/chat_test.go
+++ b/cmd/clnkr/chat_test.go
@@ -376,6 +376,23 @@ func TestChatProtocolFailure(t *testing.T) {
 	}
 }
 
+func TestChatProtocolFailureNoColorKeepsWarningWithoutANSIColor(t *testing.T) {
+	s := startupStyles(true, true)
+	c := newChatModel(80, 24, s, false)
+
+	c.appendEvent(clnkr.EventProtocolFailure{Reason: "parse_error", Raw: "not json"})
+	content := c.content.String()
+	if ansiColorPattern.MatchString(content) {
+		t.Fatalf("no-color protocol failure should not emit ANSI color codes, got: %q", content)
+	}
+	plain := stripANSI(content)
+	for _, want := range []string{iconWarning, "Protocol error:", "parse_error"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("protocol failure should contain %q, got: %q", want, plain)
+		}
+	}
+}
+
 func TestChatDebugVerbose(t *testing.T) {
 	s := defaultStyles(true)
 	c := newChatModel(80, 24, s, true) // verbose=true

--- a/cmd/clnkr/delegate.go
+++ b/cmd/clnkr/delegate.go
@@ -68,7 +68,11 @@ func (r delegateProcessRunner) Run(ctx context.Context, req delegateRequest) (de
 
 	binary := r.Binary
 	if binary == "" {
-		binary = "clnku"
+		resolved, err := defaultDelegateBinary(os.Args[0], exec.LookPath)
+		if err != nil {
+			return delegateResult{}, fmt.Errorf("delegate run: resolve clnku: %w", err)
+		}
+		binary = resolved
 	}
 
 	args := []string{"--load-messages", seedPath, "-p", req.Task, "--trajectory", outPath, "--full-send"}
@@ -111,6 +115,18 @@ func (r delegateProcessRunner) Run(ctx context.Context, req delegateRequest) (de
 	}
 
 	return delegateResult{Summary: summary, Messages: messages, TrajectoryPath: outPath}, nil
+}
+
+func defaultDelegateBinary(executable string, lookPath func(string) (string, error)) (string, error) {
+	if executable != "" {
+		if exePath, err := filepath.Abs(executable); err == nil {
+			sibling := filepath.Join(filepath.Dir(exePath), "clnku")
+			if info, err := os.Stat(sibling); err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
+				return sibling, nil
+			}
+		}
+	}
+	return lookPath("clnku")
 }
 
 func extractDelegateSummary(messages []clnkr.Message) string {

--- a/cmd/clnkr/delegate.go
+++ b/cmd/clnkr/delegate.go
@@ -96,17 +96,21 @@ func (r delegateProcessRunner) Run(ctx context.Context, req delegateRequest) (de
 	cmd.Dir = req.WorkingDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == exitClarificationNeeded {
+			messages, readErr := readDelegateMessages(outPath)
+			if readErr != nil {
+				return delegateResult{}, readErr
+			}
+			if question := extractDelegateClarification(messages); question != "" {
+				return delegateResult{Summary: "Delegate asked: " + question, Messages: messages, TrajectoryPath: outPath}, nil
+			}
+		}
 		return delegateResult{}, fmt.Errorf("delegate run: %s %s in %s: %w\n%s", binary, strings.Join(args, " "), req.WorkingDir, err, strings.TrimSpace(string(output)))
 	}
 
-	data, err := os.ReadFile(outPath)
+	messages, err := readDelegateMessages(outPath)
 	if err != nil {
-		return delegateResult{}, fmt.Errorf("delegate run: read trajectory %s: %w", filepath.Base(outPath), err)
-	}
-
-	var messages []clnkr.Message
-	if err := json.Unmarshal(data, &messages); err != nil {
-		return delegateResult{}, fmt.Errorf("delegate run: parse trajectory %s: %w", filepath.Base(outPath), err)
+		return delegateResult{}, err
 	}
 
 	summary := extractDelegateSummary(messages)
@@ -115,6 +119,19 @@ func (r delegateProcessRunner) Run(ctx context.Context, req delegateRequest) (de
 	}
 
 	return delegateResult{Summary: summary, Messages: messages, TrajectoryPath: outPath}, nil
+}
+
+func readDelegateMessages(path string) ([]clnkr.Message, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("delegate run: read trajectory %s: %w", filepath.Base(path), err)
+	}
+
+	var messages []clnkr.Message
+	if err := json.Unmarshal(data, &messages); err != nil {
+		return nil, fmt.Errorf("delegate run: parse trajectory %s: %w", filepath.Base(path), err)
+	}
+	return messages, nil
 }
 
 func defaultDelegateBinary(executable string, lookPath func(string) (string, error)) (string, error) {
@@ -127,6 +144,23 @@ func defaultDelegateBinary(executable string, lookPath func(string) (string, err
 		}
 	}
 	return lookPath("clnku")
+}
+
+func extractDelegateClarification(messages []clnkr.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Role != "assistant" {
+			continue
+		}
+		turn, err := clnkr.ParseTurn(msg.Content)
+		if err != nil {
+			continue
+		}
+		if clarify, ok := turn.(*clnkr.ClarifyTurn); ok {
+			return strings.TrimSpace(clarify.Question)
+		}
+	}
+	return ""
 }
 
 func extractDelegateSummary(messages []clnkr.Message) string {

--- a/cmd/clnkr/delegate_runner_test.go
+++ b/cmd/clnkr/delegate_runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -41,6 +42,64 @@ printf '%s\n' '[{"role":"assistant","content":"{\"type\":\"done\",\"summary\":\"
 	}
 	if len(result.Messages) != 1 {
 		t.Fatalf("messages len = %d, want 1", len(result.Messages))
+	}
+}
+
+func TestDefaultDelegateBinaryPrefersSiblingClnku(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "clnkr")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile clnkr: %v", err)
+	}
+	child := filepath.Join(dir, "clnku")
+	if err := os.WriteFile(child, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile clnku: %v", err)
+	}
+
+	got, err := defaultDelegateBinary(exe, func(string) (string, error) {
+		return "/usr/bin/clnku", nil
+	})
+	if err != nil {
+		t.Fatalf("defaultDelegateBinary: %v", err)
+	}
+	if got != child {
+		t.Fatalf("binary = %q, want sibling %q", got, child)
+	}
+}
+
+func TestDefaultDelegateBinaryFallsBackToPath(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "clnkr")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile clnkr: %v", err)
+	}
+
+	got, err := defaultDelegateBinary(exe, func(name string) (string, error) {
+		if name != "clnku" {
+			t.Fatalf("lookup name = %q, want clnku", name)
+		}
+		return "/usr/bin/clnku", nil
+	})
+	if err != nil {
+		t.Fatalf("defaultDelegateBinary: %v", err)
+	}
+	if got != "/usr/bin/clnku" {
+		t.Fatalf("binary = %q, want PATH clnku", got)
+	}
+}
+
+func TestDefaultDelegateBinaryReturnsLookupError(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "clnkr")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile clnkr: %v", err)
+	}
+
+	_, err := defaultDelegateBinary(exe, func(string) (string, error) {
+		return "", exec.ErrNotFound
+	})
+	if err == nil {
+		t.Fatal("expected lookup error")
 	}
 }
 

--- a/cmd/clnkr/delegate_runner_test.go
+++ b/cmd/clnkr/delegate_runner_test.go
@@ -45,6 +45,39 @@ printf '%s\n' '[{"role":"assistant","content":"{\"type\":\"done\",\"summary\":\"
 	}
 }
 
+func TestRunnerRunReturnsClarificationSummary(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fake-clnku")
+	script := `#!/bin/sh
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --trajectory) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' '[{"role":"assistant","content":"{\"type\":\"clarify\",\"question\":\"Which module?\"}"}]' > "$out"
+printf '%s\n' '{"type":"clarify","question":"Which module?"}'
+printf '%s\n' 'Clarification needed.' >&2
+exit 2
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	result, err := delegateProcessRunner{Binary: bin}.Run(context.Background(), delegateRequest{
+		Task:       "describe one module",
+		WorkingDir: dir,
+		Parent:     []clnkr.Message{{Role: "user", Content: "parent task"}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Summary != "Delegate asked: Which module?" {
+		t.Fatalf("Summary = %q, want clarification summary", result.Summary)
+	}
+}
+
 func TestDefaultDelegateBinaryPrefersSiblingClnku(t *testing.T) {
 	dir := t.TempDir()
 	exe := filepath.Join(dir, "clnkr")

--- a/cmd/clnkr/help.go
+++ b/cmd/clnkr/help.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/viewport"
+)
+
+type helpModel struct {
+	viewport viewport.Model
+	visible  bool
+	content  string
+}
+
+func newHelpModel() helpModel {
+	vp := viewport.New()
+	vp.SoftWrap = true
+	content := helpContent()
+	vp.SetContent(content)
+	return helpModel{viewport: vp, content: content}
+}
+
+func (h *helpModel) show(width, height int) {
+	h.visible = true
+	h.resize(width, height)
+	h.viewport.GotoTop()
+}
+
+func (h *helpModel) hide() {
+	h.visible = false
+}
+
+func (h *helpModel) resize(width, height int) {
+	if height < 1 {
+		height = 1
+	}
+	h.viewport.SetWidth(width)
+	h.viewport.SetHeight(height)
+	h.viewport.SetContent(h.content)
+}
+
+func (h helpModel) view() string {
+	if !h.visible {
+		return ""
+	}
+	return h.viewport.View()
+}
+
+func helpContent() string {
+	lines := []string{
+		"clnkr help",
+		"",
+		"Workflow",
+		"  /compact [instructions]  summarize older transcript context",
+		"  /delegate <task>         run a bounded child task",
+		"  Ctrl+Y                  reasoning trace; approve during APPROVAL",
+		"  y Enter                 approve during APPROVAL",
+		"  guidance text           revise command during APPROVAL",
+		"",
+		"Modes",
+		"  INPUT: type tasks, workflow commands, approvals, or clarifications",
+		"  SCROLL: read transcript without moving the input cursor",
+		"  RUNNING: agent or workflow command is active",
+		"  APPROVAL: approve command or type guidance",
+		"  CLARIFY: answer the agent's question",
+		"  HELP: read key and workflow help",
+		"  DIFF: review changed-file diff",
+		"  REASONING: read latest reasoning trace",
+		"",
+		"Global",
+		"  ?        help when input is empty or scroll mode is active",
+		"  Esc      enter scroll mode, or close overlays",
+		"  i        return to input mode from scroll mode",
+		"  Ctrl+C   cancel running work; quit when idle; double-press to force quit",
+		"",
+		"Input",
+		"  Enter    submit",
+		"  Ctrl+J   insert newline",
+		"  Up/Down  browse history at input edges",
+		"",
+		"Scroll",
+		"  j/k              line down/up",
+		"  gg/G             transcript top/bottom",
+		"  g/G              help overlay top/bottom",
+		"  Ctrl+D/Ctrl+U    half page down/up",
+		"  PgDn/PgUp        page down/up",
+		"  End/Home         bottom/top",
+		"",
+		"Overlays",
+		"  Ctrl+F   show changed-file diff from scroll mode",
+		"  Ctrl+Y   show latest reasoning trace; approve during APPROVAL",
+		"  Esc      close overlay",
+	}
+	return strings.Join(lines, "\n")
+}

--- a/cmd/clnkr/input_test.go
+++ b/cmd/clnkr/input_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"charm.land/lipgloss/v2"
 )
 
 func TestInputSubmitReturnsTextAndClears(t *testing.T) {
@@ -142,5 +144,14 @@ func TestInputViewContainsPrompt(t *testing.T) {
 	// View should contain the textarea rendering
 	if view == "" {
 		t.Error("view should not be empty")
+	}
+}
+
+func TestInputNoColorUsesNeutralCursorColor(t *testing.T) {
+	s := startupStyles(true, true)
+	inp := newInputModel(80, &s.Input)
+
+	if _, ok := inp.textarea.Styles().Cursor.Color.(lipgloss.NoColor); !ok {
+		t.Fatalf("cursor color = %T, want lipgloss.NoColor", inp.textarea.Styles().Cursor.Color)
 	}
 }

--- a/cmd/clnkr/main.go
+++ b/cmd/clnkr/main.go
@@ -102,6 +102,17 @@ func missingAPIKeyMessage() string {
 	return "Error: No API key found.\nSet it with: export CLNKR_API_KEY=your-api-key"
 }
 
+func noColorEnabled(getenv func(string) string) bool {
+	return getenv("NO_COLOR") != ""
+}
+
+func startupStyles(hasDark, noColor bool) *styles {
+	if noColor {
+		return monochromeStyles(hasDark)
+	}
+	return defaultStyles(hasDark)
+}
+
 func newModelForConfig(cfg providerConfig, systemPrompt string) clnkr.Model {
 	if cfg.Provider == providerconfig.ProviderAnthropic {
 		return anthropic.NewModel(cfg.BaseURL, cfg.APIKey, cfg.Model, systemPrompt)
@@ -494,7 +505,7 @@ func main() {
 }
 
 func runTUI(agent *clnkr.Agent, taskPrompt, trajectory, modelName, cwd string, eventLog *os.File, verbose bool, fullSend bool, compactorFactory compaction.Factory, delegateRunner delegateTaskRunner) {
-	s := defaultStyles(true) // TODO: detect actual background
+	s := startupStyles(true, noColorEnabled(os.Getenv)) // TODO: detect actual background
 
 	if taskPrompt != "" {
 		if !fullSend {

--- a/cmd/clnkr/main_test.go
+++ b/cmd/clnkr/main_test.go
@@ -192,6 +192,42 @@ func TestResolveProviderConfigUsesAliasesAndEnv(t *testing.T) {
 	}
 }
 
+func TestNoColorEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "unset", env: "", want: false},
+		{name: "spaces", env: "   ", want: true},
+		{name: "set", env: "1", want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := noColorEnabled(func(string) string { return tc.env })
+			if got != tc.want {
+				t.Fatalf("noColorEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStartupStylesUsesMonochromeWhenNoColorEnabled(t *testing.T) {
+	colorStyles := startupStyles(true, false)
+	monoStyles := startupStyles(true, true)
+
+	colorBadge := colorStyles.Chat.NewContent.Render("new")
+	if !ansiColorPattern.MatchString(colorBadge) {
+		t.Fatalf("color startup styles should emit ANSI color codes, got %q", colorBadge)
+	}
+
+	monoBadge := monoStyles.Chat.NewContent.Render("new")
+	if ansiColorPattern.MatchString(monoBadge) {
+		t.Fatalf("monochrome startup styles should not emit ANSI color codes, got %q", monoBadge)
+	}
+}
+
 func TestNewModelForConfigUsesOpenAIResponsesWhenConfigured(t *testing.T) {
 	var gotPath string
 

--- a/cmd/clnkr/reasoning.go
+++ b/cmd/clnkr/reasoning.go
@@ -48,7 +48,5 @@ func (r *reasoningModel) view() string {
 }
 
 func (r *reasoningModel) rendered(width int) string {
-	// Reset the shared glamour renderer so reasoning re-wraps to the modal width.
-	renderer = nil
-	return renderMarkdown(r.content, width)
+	return renderMarkdown(r.content, width, r.styles.NoColor)
 }

--- a/cmd/clnkr/reasoning_test.go
+++ b/cmd/clnkr/reasoning_test.go
@@ -40,7 +40,7 @@ func TestReasoningModelWrapsLongLines(t *testing.T) {
 	r.show(content, 20, 8)
 
 	view := r.view()
-	want := strings.TrimSpace(renderMarkdown(content, 20))
+	want := strings.TrimSpace(renderMarkdown(content, 20, false))
 	if !strings.Contains(view, want) {
 		t.Fatalf("expected modal view to contain markdown-wrapped content %q, got %q", want, view)
 	}

--- a/cmd/clnkr/render.go
+++ b/cmd/clnkr/render.go
@@ -8,26 +8,32 @@ import (
 
 // renderer caches the glamour renderer to avoid re-creating it on every call.
 var renderer *glamour.TermRenderer
+var rendererWidth int
+var rendererNoColor bool
 
 // initRenderer creates the glamour renderer with the given width.
 // Called on first render and on width changes.
-func initRenderer(width int) {
+func initRenderer(width int, noColor bool) {
 	r, err := glamour.NewTermRenderer(
-		glamour.WithStyles(retroMarkdownStyle()),
+		glamour.WithStyles(markdownStyle(noColor)),
 		glamour.WithWordWrap(width),
 	)
 	if err != nil {
 		renderer = nil
+		rendererWidth = 0
+		rendererNoColor = false
 		return
 	}
 	renderer = r
+	rendererWidth = width
+	rendererNoColor = noColor
 }
 
 // renderMarkdown passes content through glamour for styled terminal output.
 // Returns plain text on error (graceful fallback).
-func renderMarkdown(content string, width int) string {
-	if renderer == nil {
-		initRenderer(width)
+func renderMarkdown(content string, width int, noColor bool) string {
+	if renderer == nil || rendererWidth != width || rendererNoColor != noColor {
+		initRenderer(width, noColor)
 	}
 	if renderer == nil {
 		return content
@@ -37,6 +43,92 @@ func renderMarkdown(content string, width int) string {
 		return content
 	}
 	return out
+}
+
+func markdownStyle(noColor bool) ansi.StyleConfig {
+	if noColor {
+		return monochromeMarkdownStyle()
+	}
+	return retroMarkdownStyle()
+}
+
+func monochromeMarkdownStyle() ansi.StyleConfig {
+	cfg := glamourstyles.ASCIIStyleConfig
+
+	cfg.Document = ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockPrefix: "\n",
+			BlockSuffix: "\n",
+		},
+		Margin: uintPtr(0),
+	}
+	cfg.BlockQuote = ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{},
+		Indent:         uintPtr(1),
+		IndentToken:    strPtr("│ "),
+	}
+	cfg.Heading = ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockSuffix: "\n",
+			Bold:        boolPtr(true),
+		},
+	}
+	cfg.H1 = ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "# ",
+			Bold:   boolPtr(true),
+		},
+	}
+	cfg.H2 = ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "## ",
+			Bold:   boolPtr(true),
+		},
+	}
+	cfg.H3 = ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "### ",
+			Bold:   boolPtr(true),
+		},
+	}
+	cfg.H4 = ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{Prefix: "#### "}}
+	cfg.H5 = ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{Prefix: "##### "}}
+	cfg.H6 = ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{Prefix: "###### "}}
+	cfg.Strong = ansi.StylePrimitive{Bold: boolPtr(true)}
+	cfg.Emph = ansi.StylePrimitive{Underline: boolPtr(true)}
+	cfg.HorizontalRule = ansi.StylePrimitive{Format: "\n--------\n"}
+	cfg.Item = ansi.StylePrimitive{BlockPrefix: "• "}
+	cfg.Enumeration = ansi.StylePrimitive{BlockPrefix: ". "}
+	cfg.Task = ansi.StyleTask{
+		StylePrimitive: ansi.StylePrimitive{},
+		Ticked:         "[x] ",
+		Unticked:       "[ ] ",
+	}
+	cfg.Link = ansi.StylePrimitive{Underline: boolPtr(true)}
+	cfg.LinkText = ansi.StylePrimitive{Bold: boolPtr(true)}
+	cfg.Code = ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockPrefix: "`",
+			BlockSuffix: "`",
+		},
+	}
+	cfg.CodeBlock = ansi.StyleCodeBlock{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+			Margin:         uintPtr(0),
+		},
+	}
+	cfg.Table = ansi.StyleTable{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+		CenterSeparator: strPtr("|"),
+		ColumnSeparator: strPtr("|"),
+		RowSeparator:    strPtr("-"),
+	}
+	cfg.DefinitionDescription = ansi.StylePrimitive{BlockPrefix: "\n* "}
+
+	return cfg
 }
 
 func retroMarkdownStyle() ansi.StyleConfig {

--- a/cmd/clnkr/render_test.go
+++ b/cmd/clnkr/render_test.go
@@ -1,15 +1,23 @@
 package main
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
+
+var ansiColorPattern = regexp.MustCompile(`\x1b\[(?:[0-9;]*;)?(?:3[0-7]|4[0-7]|9[0-7]|10[0-7]|38;[0-9;]*|48;[0-9;]*)m`)
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiPattern.ReplaceAllString(s, "")
+}
 
 func TestRenderMarkdownBasic(t *testing.T) {
 	// Reset renderer for clean test
 	renderer = nil
 
-	out := renderMarkdown("# Hello\n\nWorld", 80)
+	out := renderMarkdown("# Hello\n\nWorld", 80, false)
 	if out == "" {
 		t.Error("renderMarkdown should produce output")
 	}
@@ -23,7 +31,7 @@ func TestRenderMarkdownCodeBlock(t *testing.T) {
 	renderer = nil
 
 	md := "```go\nfmt.Println(\"hello\")\n```"
-	out := renderMarkdown(md, 80)
+	out := renderMarkdown(md, 80, false)
 	if !strings.Contains(out, "Println") {
 		t.Errorf("code block should preserve code content, got: %q", out)
 	}
@@ -33,7 +41,7 @@ func TestRenderMarkdownFallsBackOnEmpty(t *testing.T) {
 	renderer = nil
 
 	// Empty string should still return something (glamour may add whitespace)
-	out := renderMarkdown("", 80)
+	out := renderMarkdown("", 80, false)
 	_ = out // just verify no panic
 }
 
@@ -41,10 +49,44 @@ func TestRenderMarkdownWidthChange(t *testing.T) {
 	renderer = nil
 
 	// Render at one width, then reset and render at another
-	_ = renderMarkdown("test", 40)
+	_ = renderMarkdown("test", 40, false)
 	renderer = nil // simulate width change
-	out := renderMarkdown("test", 120)
+	out := renderMarkdown("test", 120, false)
 	if out == "" {
 		t.Error("should render after width change")
+	}
+}
+
+func TestRenderMarkdownNoColorModeDropsColorButKeepsStructure(t *testing.T) {
+	renderer = nil
+
+	md := "# Heading\n\n> quote\n\n```go\nfmt.Println(\"hi\")\n```\n\n| a | b |\n| - | - |\n| 1 | 2 |"
+	out := renderMarkdown(md, 80, true)
+	if ansiColorPattern.MatchString(out) {
+		t.Fatalf("no-color markdown should not emit ANSI color codes, got %q", out)
+	}
+	plain := stripANSI(out)
+	for _, want := range []string{"Heading", "│ ", "fmt.Println", "|", "a", "b"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("no-color markdown should preserve %q, got %q", want, plain)
+		}
+	}
+}
+
+func TestRenderMarkdownRebuildsRendererWhenModeChangesInProcess(t *testing.T) {
+	renderer = nil
+
+	md := "# Heading"
+	colorOut := renderMarkdown(md, 80, false)
+	if !ansiColorPattern.MatchString(colorOut) {
+		t.Fatalf("color markdown should emit ANSI color codes, got %q", colorOut)
+	}
+
+	noColorOut := renderMarkdown(md, 80, true)
+	if ansiColorPattern.MatchString(noColorOut) {
+		t.Fatalf("no-color markdown should rebuild without ANSI color codes, got %q", noColorOut)
+	}
+	if !strings.Contains(noColorOut, "Heading") {
+		t.Fatalf("no-color markdown should still contain heading text, got %q", noColorOut)
 	}
 }

--- a/cmd/clnkr/status.go
+++ b/cmd/clnkr/status.go
@@ -55,21 +55,28 @@ func (s *statusModel) setFocus(f focusTarget) {
 	s.focus = f
 }
 
-func (s *statusModel) view(width int) string {
-	sep := s.styles.Separator.Render(" │ ")
-
-	segments := []string{
-		s.styles.ModelName.Render(s.modelName),
-		s.styles.Tokens.Render(fmt.Sprintf("%s in / %s out", formatTokens(s.inputTokens), formatTokens(s.outputTokens))),
-		s.styles.StepCount.Render(fmt.Sprintf("step %d/%d", s.stepCount, s.maxSteps)),
-		s.styles.Elapsed.Render(s.elapsedString()),
-		s.focusString(),
+func (s *statusModel) view(width int, mode, hints string) string {
+	if mode == "" {
+		mode = focusMode(s.focus)
 	}
-
-	content := strings.Join(segments, sep)
-	// Pad or truncate to fill the full width
-	bar := s.styles.Bar.Width(width).Render(content)
-	return bar
+	segments := []string{mode}
+	if width >= 40 && hints != "" {
+		segments = append(segments, truncateStatusText(hints, 28))
+	}
+	if width >= 56 {
+		segments = append(segments,
+			truncateStatusText(s.modelName, 24),
+			fmt.Sprintf("%s in / %s out", formatTokens(s.inputTokens), formatTokens(s.outputTokens)),
+		)
+	}
+	if width >= 72 {
+		segments = append(segments,
+			fmt.Sprintf("step %d/%d", s.stepCount, s.maxSteps),
+			s.elapsedString(),
+		)
+	}
+	content := truncateStatusText(strings.Join(segments, " | "), width)
+	return s.styles.Bar.Width(width).Render(content)
 }
 
 func (s *statusModel) elapsedString() string {
@@ -82,15 +89,28 @@ func (s *statusModel) elapsedString() string {
 	return formatDuration(d)
 }
 
-func (s *statusModel) focusString() string {
-	var label string
-	switch s.focus {
+func focusMode(f focusTarget) string {
+	switch f {
 	case focusInput:
-		label = "INPUT"
+		return "INPUT"
 	case focusViewport:
-		label = "SCROLL"
+		return "SCROLL"
 	}
-	return s.styles.FocusIndicator.Render(label)
+	return "INPUT"
+}
+
+func truncateStatusText(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
 }
 
 // formatTokens returns a human-readable token count (e.g., "1.2k", "15.3k", "800").

--- a/cmd/clnkr/status_test.go
+++ b/cmd/clnkr/status_test.go
@@ -15,7 +15,7 @@ func newTestStatus() statusModel {
 
 func TestStatusRendersModelName(t *testing.T) {
 	st := newTestStatus()
-	view := st.view(80)
+	view := st.view(80, "", "")
 	if !strings.Contains(view, "test-model") {
 		t.Errorf("status bar should contain model name, got: %q", view)
 	}
@@ -24,7 +24,7 @@ func TestStatusRendersModelName(t *testing.T) {
 func TestStatusRendersTokenCounts(t *testing.T) {
 	st := newTestStatus()
 	st.updateFromResponse(clnkr.Usage{InputTokens: 1200, OutputTokens: 800})
-	view := st.view(80)
+	view := st.view(80, "", "")
 	if !strings.Contains(view, "1.2k in") {
 		t.Errorf("should show input tokens, got: %q", view)
 	}
@@ -51,7 +51,7 @@ func TestStatusRendersStepCount(t *testing.T) {
 	st.incrementStep()
 	st.incrementStep()
 	st.incrementStep()
-	view := st.view(80)
+	view := st.view(80, "", "")
 	if !strings.Contains(view, "3/100") {
 		t.Errorf("should show step count 3/100, got: %q", view)
 	}
@@ -63,7 +63,7 @@ func TestStatusRendersElapsedTime(t *testing.T) {
 
 	// Simulate some elapsed time
 	st.runStart = time.Now().Add(-5 * time.Second)
-	view := st.view(80)
+	view := st.view(80, "", "")
 	if !strings.Contains(view, "5s") {
 		t.Errorf("should show elapsed time, got: %q", view)
 	}
@@ -87,15 +87,42 @@ func TestStatusStopRunFreezesElapsed(t *testing.T) {
 func TestStatusRendersFocusIndicator(t *testing.T) {
 	st := newTestStatus()
 	st.setFocus(focusInput)
-	view := st.view(80)
+	view := st.view(80, "", "")
 	if !strings.Contains(view, "INPUT") {
 		t.Errorf("should show INPUT focus indicator, got: %q", view)
 	}
 
 	st.setFocus(focusViewport)
-	view = st.view(80)
+	view = st.view(80, "", "")
 	if !strings.Contains(view, "SCROLL") {
 		t.Errorf("should show SCROLL focus indicator, got: %q", view)
+	}
+}
+
+func TestStatusViewShowsModeAndHints(t *testing.T) {
+	st := newTestStatus()
+
+	view := st.view(100, "HELP", "?/Esc close")
+	if !strings.Contains(view, "HELP") {
+		t.Fatalf("status should show mode, got %q", view)
+	}
+	if !strings.Contains(view, "?/Esc close") {
+		t.Fatalf("status should show hints, got %q", view)
+	}
+}
+
+func TestStatusNarrowViewKeepsModeWithLongModel(t *testing.T) {
+	s := defaultStyles(true)
+	st := newStatusModel("very-long-model-name-that-could-wrap-status", 100, &s.Status)
+
+	for _, width := range []int{32, 56, 72} {
+		view := st.view(width, "APPROVAL", "y Enter approve | Ctrl+Y approve")
+		if !strings.Contains(view, "APPROVAL") {
+			t.Fatalf("width %d narrow status should keep mode, got %q", width, view)
+		}
+		if strings.Count(view, "\n") != 0 {
+			t.Fatalf("width %d status should stay one line, got %q", width, view)
+		}
 	}
 }
 

--- a/cmd/clnkr/status_test.go
+++ b/cmd/clnkr/status_test.go
@@ -139,3 +139,18 @@ func TestStatusStartRunResetsPerRunState(t *testing.T) {
 		t.Error("running should be true after startRun")
 	}
 }
+
+func TestStatusNoColorViewKeepsModeWithoutANSIColor(t *testing.T) {
+	s := startupStyles(true, true)
+	st := newStatusModel("test-model", 100, &s.Status)
+
+	view := st.view(80, "RUNNING", "Esc scroll | i input")
+	if ansiColorPattern.MatchString(view) {
+		t.Fatalf("no-color status should not emit ANSI color codes, got %q", view)
+	}
+	for _, want := range []string{"RUNNING", "test-model", "Esc scroll | i input"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("status should contain %q, got %q", want, view)
+		}
+	}
+}

--- a/cmd/clnkr/styles.go
+++ b/cmd/clnkr/styles.go
@@ -48,9 +48,10 @@ type inputStyles struct {
 }
 
 type styles struct {
-	Chat   chatStyles
-	Status statusStyles
-	Input  inputStyles
+	NoColor bool
+	Chat    chatStyles
+	Status  statusStyles
+	Input   inputStyles
 }
 
 func defaultStyles(hasDark bool) *styles {
@@ -65,6 +66,7 @@ func defaultStyles(hasDark bool) *styles {
 	errColor := c("#D65A31")
 
 	return &styles{
+		NoColor: false,
 		Chat: chatStyles{
 			UserMessage:    lipgloss.NewStyle().Foreground(ink).Bold(true),
 			AssistantReply: lipgloss.NewStyle().Foreground(ink),
@@ -93,6 +95,45 @@ func defaultStyles(hasDark bool) *styles {
 			CursorLine:  lipgloss.NewStyle().Foreground(ink).Background(bgSoft),
 			Cursor:      ink,
 			Running:     lipgloss.NewStyle().Foreground(inkDim),
+		},
+	}
+}
+
+func monochromeStyles(hasDark bool) *styles {
+	_ = hasDark
+
+	noColor := lipgloss.NoColor{}
+
+	return &styles{
+		NoColor: true,
+		Chat: chatStyles{
+			UserMessage:    lipgloss.NewStyle().Bold(true),
+			AssistantReply: lipgloss.NewStyle(),
+			StreamingText:  lipgloss.NewStyle(),
+			CommandPending: lipgloss.NewStyle().Faint(true),
+			CommandSuccess: lipgloss.NewStyle().Bold(true),
+			CommandError:   lipgloss.NewStyle().Bold(true).Underline(true),
+			CommandOutput:  lipgloss.NewStyle().Faint(true),
+			Debug:          lipgloss.NewStyle().Faint(true),
+			Warning:        lipgloss.NewStyle().Bold(true),
+			NewContent:     lipgloss.NewStyle().Foreground(noColor).Background(noColor).Bold(true).Reverse(true),
+		},
+		Status: statusStyles{
+			Bar:            lipgloss.NewStyle().Bold(true).Reverse(true),
+			ModelName:      lipgloss.NewStyle().Bold(true).Reverse(true),
+			Tokens:         lipgloss.NewStyle().Reverse(true),
+			StepCount:      lipgloss.NewStyle().Reverse(true),
+			Elapsed:        lipgloss.NewStyle().Reverse(true),
+			FocusIndicator: lipgloss.NewStyle().Bold(true).Reverse(true),
+			Separator:      lipgloss.NewStyle().Reverse(true),
+		},
+		Input: inputStyles{
+			Prompt:      lipgloss.NewStyle().Bold(true),
+			Text:        lipgloss.NewStyle(),
+			Placeholder: lipgloss.NewStyle().Faint(true),
+			CursorLine:  lipgloss.NewStyle(),
+			Cursor:      noColor,
+			Running:     lipgloss.NewStyle().Faint(true),
 		},
 	}
 }

--- a/cmd/clnkr/ui.go
+++ b/cmd/clnkr/ui.go
@@ -97,6 +97,7 @@ type model struct {
 	input                 inputModel
 	status                statusModel
 	diff                  diffModel
+	help                  helpModel
 	reasoning             reasoningModel
 	files                 fileTracker
 	reasoningInfo         reasoningState
@@ -151,6 +152,7 @@ func newModel(opts modelOpts) model {
 		input:           newInputModel(0, &opts.styles.Input),
 		status:          newStatusModel(opts.modelName, opts.maxSteps, &opts.styles.Status),
 		diff:            newDiffModel(opts.styles),
+		help:            newHelpModel(),
 		reasoning:       newReasoningModel(opts.styles),
 		styles:          opts.styles,
 		shared:          &shared{compactorFactory: opts.compactorFactory, delegateRunner: opts.delegateRunner},
@@ -218,6 +220,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			chatH = 1
 		}
 		m.diff.resize(m.width, chatH)
+		m.help.resize(m.width, chatH)
 		m.reasoning.resize(m.width, chatH)
 		return m, nil
 
@@ -278,6 +281,7 @@ func (m *model) recalcLayout() {
 		chatHeight = 1
 	}
 	m.chat.resize(m.width, chatHeight)
+	m.help.resize(m.width, chatHeight)
 	m.chat.updateViewport()
 	m.input.setWidth(m.width)
 }
@@ -570,6 +574,14 @@ func (m model) handleReasoningKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.help.visible {
+		return m.handleHelpKey(msg)
+	}
+	if m.shouldOpenHelp(msg) {
+		m.openHelp()
+		return m, nil
+	}
+
 	// Diff overlay active — intercept all keys
 	if m.diff.visible {
 		return m.handleDiffKey(msg)
@@ -921,6 +933,58 @@ func (m model) handleDiffKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) shouldOpenHelp(msg tea.KeyPressMsg) bool {
+	if msg.String() != "?" {
+		return false
+	}
+	if m.focus == focusViewport {
+		return true
+	}
+	if m.awaitingApproval || m.awaitingClarification {
+		return false
+	}
+	return m.input.textarea.Value() == ""
+}
+
+func (m *model) openHelp() {
+	m.pendingG = false
+	m.diff.visible = false
+	m.reasoning.hide()
+	chatH := m.height - statusHeight - m.inputHeight()
+	if chatH < 1 {
+		chatH = 1
+	}
+	m.help.show(m.width, chatH)
+}
+
+func (m model) handleHelpKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	m.pendingG = false
+	if msg.Code == 'c' && msg.Mod == tea.ModCtrl {
+		return m.handleCtrlC()
+	}
+	switch {
+	case msg.Code == tea.KeyEscape, msg.String() == "?":
+		m.help.hide()
+	case msg.Code == 'j':
+		m.help.viewport.ScrollDown(1)
+	case msg.Code == 'k':
+		m.help.viewport.ScrollUp(1)
+	case msg.Mod == tea.ModCtrl && msg.Code == 'd':
+		m.help.viewport.HalfPageDown()
+	case msg.Mod == tea.ModCtrl && msg.Code == 'u':
+		m.help.viewport.HalfPageUp()
+	case msg.Code == tea.KeyPgDown:
+		m.help.viewport.HalfPageDown()
+	case msg.Code == tea.KeyPgUp:
+		m.help.viewport.HalfPageUp()
+	case msg.Code == tea.KeyEnd, msg.Code == 'G':
+		m.help.viewport.GotoBottom()
+	case msg.Code == tea.KeyHome, msg.Code == 'g':
+		m.help.viewport.GotoTop()
+	}
+	return m, nil
+}
+
 func (m model) handleViewportKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case msg.Code == 'j':
@@ -975,7 +1039,14 @@ func (m model) View() tea.View {
 	}
 
 	var topPane string
-	if m.reasoning.visible {
+	if m.help.visible {
+		chatH := m.height - statusHeight - m.inputHeight()
+		if chatH < 1 {
+			chatH = 1
+		}
+		m.help.resize(m.width, chatH)
+		topPane = m.help.view()
+	} else if m.reasoning.visible {
 		topPane = m.reasoning.view()
 	} else if m.diff.visible {
 		topPane = m.diff.view()
@@ -990,10 +1061,52 @@ func (m model) View() tea.View {
 		}
 	}
 
-	statusView := m.status.view(m.width)
+	statusView := m.status.view(m.width, m.statusMode(), m.statusHints())
 	inputView := m.input.view()
 
 	view := tea.NewView(topPane + "\n" + statusView + "\n" + inputView)
 	view.ReportFocus = true
 	return view
+}
+
+func (m model) statusMode() string {
+	switch {
+	case m.help.visible:
+		return "HELP"
+	case m.diff.visible:
+		return "DIFF"
+	case m.reasoning.visible:
+		return "REASONING"
+	case m.awaitingApproval:
+		return "APPROVAL"
+	case m.awaitingClarification:
+		return "CLARIFY"
+	case m.running:
+		return "RUNNING"
+	case m.focus == focusViewport:
+		return "SCROLL"
+	default:
+		return "INPUT"
+	}
+}
+
+func (m model) statusHints() string {
+	switch m.statusMode() {
+	case "HELP":
+		return "?/Esc close"
+	case "DIFF":
+		return "j/k scroll | Esc close"
+	case "REASONING":
+		return "j/k scroll | Esc close"
+	case "APPROVAL":
+		return "y Enter approve | Ctrl+Y approve"
+	case "CLARIFY":
+		return "Enter send clarification"
+	case "RUNNING":
+		return "Ctrl+C cancel"
+	case "SCROLL":
+		return "i input | ? help | Ctrl+F diff"
+	default:
+		return "Enter send | ? help"
+	}
 }

--- a/cmd/clnkr/ui_test.go
+++ b/cmd/clnkr/ui_test.go
@@ -82,6 +82,315 @@ func TestModelFocusToggle(t *testing.T) {
 	}
 }
 
+func questionKey() tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: '/', Mod: tea.ModShift, Text: "?"}
+}
+
+func TestModelQuestionMarkOpensHelpOverlay(t *testing.T) {
+	m := setupModel()
+
+	m = updateModel(t, m, questionKey())
+	if !m.help.visible {
+		t.Fatal("expected help overlay to be visible")
+	}
+	view := m.View()
+	for _, want := range []string{"clnkr help", "/compact [instructions]", "/delegate <task>", "Ctrl+Y"} {
+		if !strings.Contains(view.Content, want) {
+			t.Fatalf("help view missing %q: %q", want, view.Content)
+		}
+	}
+}
+
+func TestModelQuestionMarkDoesNotStealComposedInput(t *testing.T) {
+	m := setupModel()
+	m.running = false
+	m.input.textarea.SetValue("what changed")
+
+	m = updateModel(t, m, questionKey())
+	if m.help.visible {
+		t.Fatal("? should not open help while composing non-empty input")
+	}
+	if got := m.input.textarea.Value(); got != "what changed?" {
+		t.Fatalf("input = %q, want question mark inserted", got)
+	}
+}
+
+func TestModelQuestionMarkDoesNotStealApprovalOrClarificationInput(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		approval      bool
+		clarification bool
+	}{
+		{name: "approval", approval: true},
+		{name: "clarification", clarification: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := setupModel()
+			m.running = true
+			m.awaitingApproval = tc.approval
+			m.awaitingClarification = tc.clarification
+			m.input.textarea.SetValue("why")
+
+			m = updateModel(t, m, questionKey())
+			if m.help.visible {
+				t.Fatal("? should not open help during active prompt text entry")
+			}
+			if got := m.input.textarea.Value(); got != "why?" {
+				t.Fatalf("input = %q, want question mark inserted", got)
+			}
+
+			m.input.textarea.Reset()
+			m = updateModel(t, m, questionKey())
+			if m.help.visible {
+				t.Fatal("? should not open help during empty active prompt text entry")
+			}
+			if got := m.input.textarea.Value(); got != "?" {
+				t.Fatalf("empty prompt input = %q, want question mark inserted", got)
+			}
+		})
+	}
+}
+
+func TestModelQuestionMarkOpensHelpInScrollModeDuringPrompts(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		approval      bool
+		clarification bool
+	}{
+		{name: "approval", approval: true},
+		{name: "clarification", clarification: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := setupModel()
+			m.running = true
+			m.awaitingApproval = tc.approval
+			m.awaitingClarification = tc.clarification
+			m.focus = focusViewport
+			m.input.textarea.Blur()
+
+			m = updateModel(t, m, questionKey())
+			if !m.help.visible {
+				t.Fatal("? should open help from scroll mode during prompts")
+			}
+		})
+	}
+}
+
+func TestModelHelpHidesOtherOverlays(t *testing.T) {
+	m := setupModel()
+	m.diff.visible = true
+	m.reasoning.show("trace", 80, 20)
+
+	m = updateModel(t, m, questionKey())
+	if !m.help.visible {
+		t.Fatal("expected help overlay to be visible")
+	}
+	if m.diff.visible || m.reasoning.visible {
+		t.Fatalf("help should hide other overlays, diff=%v reasoning=%v", m.diff.visible, m.reasoning.visible)
+	}
+}
+
+func TestModelEscapeDismissesHelpOverlay(t *testing.T) {
+	m := setupModel()
+	m.focus = focusInput
+	m.help.show(80, 20)
+
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.help.visible {
+		t.Fatal("expected help overlay to be hidden")
+	}
+	if m.focus != focusInput {
+		t.Fatalf("help dismissal should not change focus, got %v", m.focus)
+	}
+}
+
+func TestModelQuestionMarkDismissesHelpOverlay(t *testing.T) {
+	m := setupModel()
+	m.help.show(80, 20)
+
+	m = updateModel(t, m, questionKey())
+	if m.help.visible {
+		t.Fatal("expected ? to hide visible help overlay")
+	}
+}
+
+func TestModelHelpOverlayBlocksNormalKeys(t *testing.T) {
+	m := setupModel()
+	m.help.show(80, 20)
+	m.focus = focusViewport
+
+	m = updateModel(t, m, tea.KeyPressMsg{Code: 'i'})
+	if m.focus != focusViewport {
+		t.Fatal("help overlay should block normal focus-changing keys")
+	}
+	if !m.help.visible {
+		t.Fatal("help overlay should remain visible after unrelated key")
+	}
+}
+
+func TestModelHelpOverlayLetsCtrlCCancel(t *testing.T) {
+	cancelled := false
+	m := setupModel()
+	m.running = true
+	m.cancel = func() { cancelled = true }
+	m.help.show(80, 20)
+
+	m = updateModel(t, m, tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if !cancelled {
+		t.Fatal("Ctrl+C should cancel while help is visible")
+	}
+}
+
+func TestModelOpeningHelpClearsPendingGGChord(t *testing.T) {
+	m := setupModel()
+	m.focus = focusViewport
+	m.pendingG = true
+
+	m = updateModel(t, m, questionKey())
+	if !m.help.visible {
+		t.Fatal("expected help overlay to be visible")
+	}
+	if m.pendingG {
+		t.Fatal("opening help should clear pending gg chord")
+	}
+}
+
+func TestModelHelpOverlayHandlesDocumentedScrollKeys(t *testing.T) {
+	m := setupModel()
+	m.help.show(40, 6)
+	m.focus = focusViewport
+
+	for _, key := range []tea.KeyPressMsg{
+		{Code: 'j'},
+		{Code: 'k'},
+		{Code: 'd', Mod: tea.ModCtrl},
+		{Code: 'u', Mod: tea.ModCtrl},
+		{Code: tea.KeyPgDown},
+		{Code: tea.KeyPgUp},
+		{Code: tea.KeyEnd},
+		{Code: tea.KeyHome},
+		{Code: 'G'},
+		{Code: 'g'},
+	} {
+		m = updateModel(t, m, key)
+		if !m.help.visible {
+			t.Fatalf("help overlay should remain visible after %v", key)
+		}
+		if m.focus != focusViewport {
+			t.Fatalf("help scroll key %v should not change focus", key)
+		}
+	}
+}
+
+func TestModelHelpOverlayKeepsStatusModeAndInputVisibleOnSmallTerminal(t *testing.T) {
+	m := setupModel()
+	m = updateModel(t, m, tea.WindowSizeMsg{Width: 40, Height: 12})
+	m = updateModel(t, m, questionKey())
+
+	view := m.View()
+	if !strings.Contains(view.Content, "clnkr help") {
+		t.Fatalf("help content should render, got %q", view.Content)
+	}
+	lines := strings.Split(view.Content, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("view should include status and input lines, got %q", view.Content)
+	}
+	statusLine := lines[len(lines)-2]
+	if !strings.Contains(statusLine, "HELP") {
+		t.Fatalf("status mode should remain visible, status=%q view=%q", statusLine, view.Content)
+	}
+	if !strings.Contains(view.Content, iconPrompt) {
+		t.Fatalf("input should remain visible, got %q", view.Content)
+	}
+	if got, max := strings.Count(view.Content, "\n")+1, 12; got > max {
+		t.Fatalf("view line count = %d, want <= %d; view=%q", got, max, view.Content)
+	}
+}
+
+func TestModelStatusModeReflectsInput(t *testing.T) {
+	m := setupModel()
+	m.running = false
+	m.focus = focusInput
+
+	view := m.View()
+	if !strings.Contains(view.Content, "INPUT") {
+		t.Fatalf("status should show INPUT mode, got %q", view.Content)
+	}
+}
+
+func TestModelStatusModeReflectsScroll(t *testing.T) {
+	m := setupModel()
+	m.running = false
+	m.focus = focusViewport
+
+	view := m.View()
+	if !strings.Contains(view.Content, "SCROLL") {
+		t.Fatalf("status should show SCROLL mode, got %q", view.Content)
+	}
+}
+
+func TestModelStatusModeReflectsHelpOverlay(t *testing.T) {
+	m := setupModel()
+	m.help.show(80, 20)
+
+	view := m.View()
+	if !strings.Contains(view.Content, "HELP") {
+		t.Fatalf("status should show HELP mode, got %q", view.Content)
+	}
+}
+
+func TestModelStatusModeReflectsDiffOverlay(t *testing.T) {
+	m := setupModel()
+	m.diff.visible = true
+
+	view := m.View()
+	if !strings.Contains(view.Content, "DIFF") {
+		t.Fatalf("status should show DIFF mode, got %q", view.Content)
+	}
+}
+
+func TestModelStatusModeReflectsReasoningOverlay(t *testing.T) {
+	m := setupModel()
+	m.reasoning.visible = true
+
+	view := m.View()
+	if !strings.Contains(view.Content, "REASONING") {
+		t.Fatalf("status should show REASONING mode, got %q", view.Content)
+	}
+}
+
+func TestModelStatusModeReflectsApproval(t *testing.T) {
+	m := setupModel()
+	m.awaitingApproval = true
+
+	view := m.View()
+	if !strings.Contains(view.Content, "APPROVAL") {
+		t.Fatalf("status should show APPROVAL mode, got %q", view.Content)
+	}
+}
+
+func TestModelStatusModeReflectsClarification(t *testing.T) {
+	m := setupModel()
+	m.awaitingClarification = true
+
+	view := m.View()
+	if !strings.Contains(view.Content, "CLARIFY") {
+		t.Fatalf("status should show CLARIFY mode, got %q", view.Content)
+	}
+}
+
+func TestModelStatusModeReflectsRunningWithoutPrompt(t *testing.T) {
+	m := setupModel()
+	m.running = true
+	m.awaitingApproval = false
+	m.awaitingClarification = false
+
+	view := m.View()
+	if !strings.Contains(view.Content, "RUNNING") {
+		t.Fatalf("status should show RUNNING mode, got %q", view.Content)
+	}
+}
+
 func TestModelAgentDone(t *testing.T) {
 	m := setupModel()
 	um := updateModel(t, m, agentDoneMsg{err: nil})

--- a/cmd/clnkr/ui_test.go
+++ b/cmd/clnkr/ui_test.go
@@ -17,6 +17,10 @@ import (
 
 func setupModel() model {
 	s := defaultStyles(true)
+	return setupModelWithStyles(s)
+}
+
+func setupModelWithStyles(s *styles) model {
 	m := newModel(modelOpts{
 		styles:    s,
 		modelName: "test-model",
@@ -61,6 +65,25 @@ func TestModelHandlesEventResponse(t *testing.T) {
 	view := um.View()
 	if !strings.Contains(view.Content, "full response") {
 		t.Error("View should contain authoritative response content")
+	}
+}
+
+func TestUINoColorViewStaysMonochromeWithNewContentIndicator(t *testing.T) {
+	m := setupModelWithStyles(startupStyles(true, true))
+	m.chat.content.WriteString("assistant output\n")
+	m.chat.hasNew = true
+	m.chat.viewport.SetContent(m.chat.content.String())
+	m.input.textarea.SetValue("follow up")
+
+	view := m.View()
+	if ansiColorPattern.MatchString(view.Content) {
+		t.Fatalf("no-color view should not emit ANSI color codes, got %q", view.Content)
+	}
+	plain := stripANSI(view.Content)
+	for _, want := range []string{"new content", "RUNNING", iconPrompt, "follow up"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("view should contain %q, got %q", want, plain)
+		}
 	}
 }
 

--- a/design.md
+++ b/design.md
@@ -1,0 +1,59 @@
+# NO_COLOR Monochrome Design
+
+## Architecture
+
+`cmd/clnkr` keeps one startup theme decision: color enabled or `NO_COLOR` monochrome. A small pure helper computes that mode once, `runTUI` builds a `styles` set for chat, status, and input from it, and the same mode goes into markdown rendering.
+
+The monochrome path is subtractive first. It removes ANSI color from Lip Gloss and Glamour output, then adds only a few non-color emphasis choices where existing output would get too flat: warning and error lines, the new-content badge, and input focus. Status stays mostly text-driven because it already emits explicit mode words.
+
+## Components And Boundaries
+
+- `cmd/clnkr/main.go`
+  Reads `NO_COLOR` once at TUI startup through a small helper and passes `noColor` into style and renderer setup.
+- `cmd/clnkr/styles.go`
+  Builds either the existing color palette or a monochrome variant. Preserve the existing `defaultStyles(true)` API for color mode and add a separate startup seam for monochrome so the current test surface stays stable. Monochrome uses `lipgloss.NoColor{}` for foreground, background, and cursor, plus narrow non-color emphasis for the few stateful surfaces that need it.
+- `cmd/clnkr/render.go`
+  Builds Glamour styles from the same `noColor` input. Color mode keeps the current retro style. No-color mode keeps a small custom monochrome variant: preserve heading prefixes, block quote markers, list markers, code-block framing, and table separators, but remove explicit color and background fields. Renderer caching becomes mode-aware so a cached color renderer cannot bleed into no-color output.
+- Existing chat, status, reasoning, input, and UI code
+  Consume the same `styles` struct. `chat` and `reasoning` also need explicit markdown mode plumbing because they are the render call sites. No new UI flow, no new mode, no new public flags.
+
+## Data Flow
+
+1. `runTUI` checks `NO_COLOR`.
+2. `runTUI` builds `styles` with that result.
+3. Chat, status, input, reasoning, and overlays render through those styles as they already do.
+4. Markdown rendering receives the same mode and chooses the matching Glamour style config.
+5. Tests exercise both modes in-process so renderer reuse bugs show up.
+
+## Failure Handling
+
+- If `NO_COLOR` is unset or empty, behavior stays on the existing color path.
+- If the markdown renderer cannot initialize, existing plain-text fallback remains unchanged.
+- If monochrome output is too flat in one state, add local non-color emphasis there instead of broad redesign.
+
+## Testing Strategy
+
+- Start with failing tests.
+- Add markdown tests that render once in color mode and once in no-color mode in the same process.
+- Assert no-color markdown output drops color-setting escapes while preserving the chosen monochrome structure: heading prefixes, block quote markers, code-block framing, and table separators.
+- Add style or view-level tests for stateful TUI surfaces that matter here:
+  - input cursor path is neutralized
+  - warning or error text remains distinct without color
+  - new-content badge remains visible without color
+- Add one status-level or full `model.View()` no-color assertion that preserves mode text and one-line layout without color-setting escapes.
+- Add one composed `model.View()` no-color assertion that uses the same startup style-selection seam as `runTUI`, includes `m.chat.hasNew = true`, and proves chat, status, input, and the new-content badge stay monochrome together.
+- Keep existing TUI layout tests passing. Final verification still runs `make _fmt` and `make check`.
+
+## Non-Goals
+
+- No new CLI flag or config file for color control.
+- No runtime theme switching after TUI startup.
+- No background detection work beyond keeping room for it later.
+- No feature work in `cmd/clnku`.
+- No broad visual redesign of the TUI.
+
+## Tradeoffs
+
+- A small custom monochrome variant is more code than stock Glamour ASCII, but it better matches the brief because it preserves structure instead of dropping to plain fallback.
+- Keying markdown rendering by mode adds a little plumbing, but it prevents stale renderer reuse in tests and future code paths.
+- Targeted non-color emphasis is slightly more subjective than pure subtraction. It is still lower risk than leaving important state changes visually flat.

--- a/evaluations/suites/responses-history-live/suite.json
+++ b/evaluations/suites/responses-history-live/suite.json
@@ -1,0 +1,13 @@
+{
+  "id": "responses-history-live",
+  "description": "Live-provider OpenAI Responses seeded assistant history suite",
+  "mode": "live-provider",
+  "trials_per_task": 1,
+  "failure_policy": {
+    "stop_on_first_failure": true,
+    "max_failed_tasks": 1
+  },
+  "tasks": [
+    "001-seeded-assistant-history"
+  ]
+}

--- a/evaluations/suites/responses-history-live/tasks/001-seeded-assistant-history/input/instruction.txt
+++ b/evaluations/suites/responses-history-live/tasks/001-seeded-assistant-history/input/instruction.txt
@@ -1,0 +1,1 @@
+Create `responses-history-note.txt` in the repo root with the contents `responses-history-ok` and then finish.

--- a/evaluations/suites/responses-history-live/tasks/001-seeded-assistant-history/input/seed-transcript.json
+++ b/evaluations/suites/responses-history-live/tasks/001-seeded-assistant-history/input/seed-transcript.json
@@ -1,0 +1,10 @@
+[
+  {
+    "role": "user",
+    "content": "Previous task: say hello."
+  },
+  {
+    "role": "assistant",
+    "content": "{\"type\":\"clarify\",\"question\":\"hello\",\"reasoning\":null}"
+  }
+]

--- a/evaluations/suites/responses-history-live/tasks/001-seeded-assistant-history/task.json
+++ b/evaluations/suites/responses-history-live/tasks/001-seeded-assistant-history/task.json
@@ -1,0 +1,36 @@
+{
+  "id": "001-seeded-assistant-history",
+  "instruction_file": "input/instruction.txt",
+  "seed_transcript_file": "input/seed-transcript.json",
+  "working_directory": ".",
+  "full_send": true,
+  "step_limit": 5,
+  "mode": "live-provider",
+  "graders": {
+    "outcome_diff": {
+      "enabled": true,
+      "required": true
+    },
+    "outcome_command_output": {
+      "enabled": true,
+      "required": true,
+      "command": [
+        "bash",
+        "-lc",
+        "actual=$(cat responses-history-note.txt); [ \"$actual\" = \"responses-history-ok\" ] && printf '%s\\n' \"$actual\""
+      ],
+      "expected_exit_code": 0,
+      "stdout_contains": [
+        "responses-history-ok"
+      ]
+    },
+    "transcript_command_trace": {
+      "enabled": true,
+      "required": false,
+      "expected_exit_codes": [
+        0
+      ],
+      "max_command_count": 3
+    }
+  }
+}

--- a/internal/providers/openairesponses/openairesponses.go
+++ b/internal/providers/openairesponses/openairesponses.go
@@ -55,11 +55,11 @@ type responseFormat struct {
 }
 
 type inputMessage struct {
-	Role    string          `json:"role"`
-	Content []inputTextItem `json:"content"`
+	Role    string      `json:"role"`
+	Content []inputItem `json:"content"`
 }
 
-type inputTextItem struct {
+type inputItem struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
 }
@@ -166,13 +166,20 @@ func mapMessages(messages []clnkr.Message) []inputMessage {
 	for _, msg := range normalized {
 		input = append(input, inputMessage{
 			Role: msg.Role,
-			Content: []inputTextItem{{
-				Type: "input_text",
+			Content: []inputItem{{
+				Type: responsesInputContentType(msg.Role),
 				Text: msg.Content,
 			}},
 		})
 	}
 	return input
+}
+
+func responsesInputContentType(role string) string {
+	if role == "assistant" {
+		return "output_text"
+	}
+	return "input_text"
 }
 
 func (m *Model) doRequest(ctx context.Context, body []byte) ([]byte, int, string, error) {

--- a/internal/providers/openairesponses/openairesponses_test.go
+++ b/internal/providers/openairesponses/openairesponses_test.go
@@ -175,6 +175,9 @@ func TestModelQueryTextOmitsStructuredOutputConfigAndNormalizesAssistantHistory(
 	if !ok {
 		t.Fatalf("input[1].content[0] = %#v, want map", content[0])
 	}
+	if got, want := item["type"], "output_text"; got != want {
+		t.Fatalf("assistant content type = %#v, want %q", got, want)
+	}
 	if got, want := item["text"], `{"turn":{"type":"done","bash":null,"question":null,"summary":"canonical transcript","reasoning":null}}`; got != want {
 		t.Fatalf("assistant text = %#v, want %q", got, want)
 	}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,65 @@
+# NO_COLOR Monochrome Implementation Plan
+
+**Goal:** Honor `NO_COLOR` in `cmd/clnkr`, remove ANSI color from TUI and markdown output, and keep important states legible with minimal monochrome emphasis.
+
+**Ordered tasks**
+
+1. Add red tests for a pure `NO_COLOR` detection helper, a pure startup style-selection seam, markdown mode switching, status-bar no-color rendering, and one composed `model.View()` no-color path with `hasNew` enabled.
+   Targets: `cmd/clnkr/render_test.go`, `cmd/clnkr/main_test.go` or a new focused test file, `cmd/clnkr/status_test.go`, `cmd/clnkr/ui_test.go`
+   Verification: `cd cmd/clnkr && go test ./... -run 'TestRenderMarkdown|Test.*NoColor|TestStatus.*NoColor|TestUI.*NoColor'`
+
+2. Add a small pure helper for startup-only `NO_COLOR` detection and a pure startup style-selection seam, then wire them into the TUI path.
+   Targets: `cmd/clnkr/main.go`
+   Verification: focused tests for `noColorEnabled(getenv)` and the startup style-selection seam.
+
+3. Preserve the existing color-style API and add a separate monochrome style builder used only by startup theme selection.
+   Targets: `cmd/clnkr/styles.go`
+   Verification: focused tests for monochrome style outputs plus the existing module test suite to catch unchanged direct callers.
+
+4. Neutralize the dedicated input cursor color path and add only the minimum non-color emphasis needed for focus and state changes.
+   Targets: `cmd/clnkr/styles.go`, `cmd/clnkr/input.go` if needed, `cmd/clnkr/ui.go`
+   Verification: focused tests covering cursor styling, warnings or errors, and new-content badge visibility through `model.View()`.
+
+5. Make markdown rendering no-color aware with a small custom monochrome variant, thread mode explicitly through `chat` and `reasoning`, and fix the renderer cache so mode changes in one process rebuild correctly.
+   Targets: `cmd/clnkr/render.go`, `cmd/clnkr/reasoning.go`, `cmd/clnkr/chat.go`
+   Verification: focused markdown tests that render color then no-color in the same process and assert preserved monochrome structure: heading prefixes, block quote markers, code-block framing, and table separators.
+
+6. Run module-level verification, then repo-level verification.
+   Verification:
+   - `cd cmd/clnkr && go test ./...`
+   - `make _fmt`
+   - `make check`
+
+**File and module targets**
+
+- `cmd/clnkr/main.go`
+- `cmd/clnkr/styles.go`
+- `cmd/clnkr/render.go`
+- `cmd/clnkr/chat.go`
+- `cmd/clnkr/reasoning.go`
+- `cmd/clnkr/ui.go`
+- `cmd/clnkr/render_test.go`
+- `cmd/clnkr/main_test.go` or new no-color-focused tests
+- `cmd/clnkr/status_test.go`
+- `cmd/clnkr/ui_test.go`
+- Possibly `cmd/clnkr/input_test.go`, `cmd/clnkr/chat_test.go`, `cmd/clnkr/reasoning_test.go`, `cmd/clnkr/delegate_chat_test.go`, or `cmd/clnkr/program_integration_test.go` if the startup seam or style builder changes require mechanical updates
+
+**Risks and rollback notes**
+
+- Risk: monochrome output becomes too flat.
+  Rollback note: keep changes local to style builders and markdown style config so emphasis can be reduced or removed without touching core TUI flow.
+- Risk: renderer cache keeps stale color mode.
+  Rollback note: make cache invalidation explicit and covered by same-process tests before final verification.
+- Risk: style constructor changes ripple through many tests.
+  Rollback note: keep the public builder shape simple and update tests mechanically where possible.
+
+**Explicit assumptions**
+
+- `NO_COLOR` only affects `cmd/clnkr` in this feature.
+- Startup-only detection is sufficient.
+- A pure helper such as `noColorEnabled(getenv func(string) string) bool` is an acceptable seam for testing startup behavior.
+- A pure startup style-selection seam is preferable to changing the signature of `defaultStyles(true)` because many existing tests call it directly.
+- Non-color emphasis like bold, reverse, underline, prefixes, and borders is allowed in monochrome mode.
+- Markdown no-color output keeps a named custom monochrome structure rather than dropping all the way to stock Glamour ASCII defaults.
+- Status bar readability is mostly a verification concern because mode labels are already explicit text.
+- One composed startup-seam test is enough proof that monochrome styles reach the assembled TUI without needing to run Bubble Tea itself in the test.

--- a/research.md
+++ b/research.md
@@ -1,0 +1,111 @@
+# Problem statement
+
+`cmd/clnkr` always builds a colorized retro theme for the TUI and a colorized Glamour markdown renderer. Verified requirement from the feature brief: “honor `NO_COLOR`,” “preserve bold, spacing, borders, labels, and explicit mode text,” “ensure focused/active/error state remains legible without color,” and “make markdown rendering switch to a no-color style config” (`/home/bcosgrove/tmp/tui-multiagent-coord/clnkr-03-no-color-monochrome.md:17-21`). That is narrower than “disable styling,” and it matches the current code paths that hard-code color in both Lip Gloss and Glamour (`cmd/clnkr/styles.go:56-98`, `cmd/clnkr/render.go:14-205`).
+
+## Current repo constraints and relevant code paths
+
+- `cmd/clnkr` is its own Go module with Charm dependencies isolated there, not in the root module (`cmd/clnkr/go.mod:1-15`; `AGENTS.md` “Architecture” and “Rules”).
+- Repository guidance explicitly says `cmd/clnkr` does not need feature parity with `cmd/clnku`, so `NO_COLOR` can be implemented only in the TUI without changing the plain CLI (`AGENTS.md` “Rules”).
+- `runTUI` always calls `defaultStyles(true)` and never reads `NO_COLOR`; the `true` argument is hard-coded and annotated with `TODO: detect actual background` (`cmd/clnkr/main.go:496-497`).
+- `defaultStyles` ignores its `hasDark` parameter and constructs every chat, status, and input style from explicit hex colors, including foreground, background, cursor, and error accents (`cmd/clnkr/styles.go:56-98`).
+- UI state visibility depends on those styles in a few concentrated places:
+  - chat command pending/success/error/debug/warning/new-content indicator (`cmd/clnkr/chat.go:90-145`, `cmd/clnkr/ui.go:1053-1061`)
+  - status bar mode/hints line (`cmd/clnkr/status.go:58-80`, `cmd/clnkr/ui.go:1072-1111`)
+  - textarea prompt/text/placeholder/cursor-line/cursor wiring, including a dedicated cursor color path (`cmd/clnkr/input.go:18-45`, `cmd/clnkr/styles.go:35-47,91-95`)
+- Markdown rendering is also globally colorized. `initRenderer` caches one shared Glamour `TermRenderer` built with `glamour.WithStyles(retroMarkdownStyle())` and `glamour.WithWordWrap(width)` (`cmd/clnkr/render.go:9-24`). `retroMarkdownStyle` starts from `glamourstyles.ASCIIStyleConfig` but then reintroduces explicit colors and backgrounds for headings, links, code, code blocks, tables, and block quotes (`cmd/clnkr/render.go:42-205`).
+- Renderer cache invalidation is width-driven only. `chat.resize` and `reasoning.rendered` clear the package-global `renderer`, but there is no theme key in that cache today. A startup-only implementation can still avoid stale renders by keying the cache on `noColor` state or by rebuilding when the requested mode differs from the cached mode (`cmd/clnkr/chat.go:293-298`, `cmd/clnkr/reasoning.go:50-53`, `cmd/clnkr/render.go:9-31`).
+- Existing tests cover normal rendering and layout, but nothing in `cmd/clnkr` asserts `NO_COLOR` behavior today:
+  - `render_test.go` checks only “transforms markdown,” code-block preservation, empty input, and width change (`cmd/clnkr/render_test.go:8-50`)
+  - many tests construct `defaultStyles(true)` directly, so a signature or behavior change will ripple across the TUI tests (`cmd/clnkr/ui_test.go:18-30`, `cmd/clnkr/status_test.go:11-16`, `cmd/clnkr/input_test.go:8-18`)
+- Verified baseline: `go test ./...` passes in `cmd/clnkr` in this worktree (`cmd/clnkr`: local command run on 2026-04-23, output `ok github.com/clnkr-ai/clnkr/cmd/clnkr 0.954s`).
+
+## External constraints or APIs
+
+- `NO_COLOR` convention: command-line software that adds ANSI color by default should check `NO_COLOR`; if the variable is present and not empty, ANSI color should be prevented regardless of value. User-level override example is `NO_COLOR=1` (`https://no-color.org/`, lines 7-10).
+- Lip Gloss exposes `NoColor`, defined as “absence of color styling”; with it, foreground uses terminal default text color and background is not drawn (`/home/bcosgrove/go/pkg/mod/charm.land/lipgloss/v2@v2.0.1/color.go:45-60`; also `https://pkg.go.dev/charm.land/lipgloss/v2`, lines 2327-2340).
+- Lip Gloss `Style.Foreground` and `Style.Background` accept `color.Color`, so monochrome styles can stay in the same API surface by swapping color values rather than replacing the rendering stack (`/home/bcosgrove/go/pkg/mod/charm.land/lipgloss/v2@v2.0.1/set.go:272-280`).
+- Lip Gloss docs recommend Bubble Tea apps detect terminal background via `tea.BackgroundColorMsg`, while standalone usage can call `lipgloss.HasDarkBackground`; current `cmd/clnkr` does neither (`https://pkg.go.dev/charm.land/lipgloss/v2`, lines 1110-1144 and 1703-1719; `cmd/clnkr/main.go:496-497`).
+- Glamour supports swapping markdown style configs directly through `glamour.WithStyles(styles ansi.StyleConfig)` and keeping wrapping via `glamour.WithWordWrap(width)` (`/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/glamour.go:163-195`; also `https://pkg.go.dev/github.com/charmbracelet/glamour`, lines 435-461).
+- Glamour ships `ASCIIStyleConfig`, documented as using only ASCII characters, and `NoTTYStyleConfig` is an alias of that config (`/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/styles/styles.go:29-90,662-670`; also `https://pkg.go.dev/github.com/charmbracelet/glamour/styles`, lines 1339-1348).
+
+## Viable approaches with tradeoffs
+
+### 1. Add explicit `noColor` theme branching in `cmd/clnkr`
+
+Build styles from a small theme decision at startup, pass that through to both Lip Gloss styles and the markdown renderer, and keep existing layout/state strings unchanged. In the no-color branch, swap foreground/background uses to `lipgloss.NoColor{}` and use non-color attributes already supported by Lip Gloss and Glamour, such as `Bold`, `Faint`, `Underline`, prefixes, ASCII separators, and existing icons (`cmd/clnkr/styles.go:18-98`; `/home/bcosgrove/go/pkg/mod/charm.land/lipgloss/v2@v2.0.1/color.go:45-60`; `/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/styles/styles.go:29-90`).
+
+Tradeoff: lowest product risk if focused on the explicit brief requirements and kept startup-only for now, which matches the current `runTUI` lifecycle (`cmd/clnkr/main.go:496-497`). It still needs one explicit renderer-cache rule so a color renderer cannot be reused when `NO_COLOR` is requested later in the same process.
+
+### 2. Reuse Glamour ASCII/NoTTY for markdown and keep a custom monochrome Lip Gloss palette
+
+For markdown only, switch `retroMarkdownStyle()` to return `glamourstyles.NoTTYStyleConfig` or `ASCIIStyleConfig` when `NO_COLOR` is active, while separately designing TUI monochrome Lip Gloss styles for status/input/chat (`cmd/clnkr/render.go:42-205`; `/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/styles/styles.go:29-90,662-670`).
+
+Tradeoff: simplest markdown path and closest match to upstream no-color behavior, but stock ASCII Glamour will not preserve the current retro visual accents. Example: current H1 uses inverted foreground/background banner styling, while ASCII falls back to textual heading prefixes (`cmd/clnkr/render.go:66-74`; `/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/styles/styles.go:57-85`). That may undershoot the brief’s “intentional monochrome pass.”
+
+### 3. Keep one renderer/style builder API that accepts both `hasDark` and `noColor`
+
+Refactor `defaultStyles(hasDark bool)` and markdown style creation into paired builders that accept explicit runtime theme inputs, then initialize them from Bubble Tea background-color detection plus `NO_COLOR` precedence. This addresses the existing `TODO` and prevents another round of theme plumbing later (`cmd/clnkr/styles.go:56-57`; `cmd/clnkr/main.go:496-497`; `https://pkg.go.dev/charm.land/lipgloss/v2`, lines 1118-1130).
+
+Tradeoff: best long-term shape, but more scope than the feature strictly needs. It touches startup behavior and likely requires new tests for background detection plumbing in addition to `NO_COLOR`.
+
+### 4. Minimal env gate only
+
+Check `NO_COLOR`, set Lip Gloss colors to `NoColor`, and remove Glamour color fields without otherwise redesigning states (`/home/bcosgrove/go/pkg/mod/charm.land/lipgloss/v2@v2.0.1/color.go:45-60`; `cmd/clnkr/styles.go:67-96`; `cmd/clnkr/render.go:42-205`).
+
+Tradeoff: smallest patch, but highest UX risk. Current error, new-content, cursor-line, and cursor styling rely on color contrast, so a purely subtractive pass may flatten important distinctions or leave one remaining color path behind (`cmd/clnkr/styles.go:78-96`; `cmd/clnkr/ui.go:1055-1065`; `cmd/clnkr/input.go:29-45`).
+
+## Open questions
+
+- `NO_COLOR` should take precedence over automatic background detection for this feature. That matches the external convention for default color output and keeps startup behavior deterministic. A future explicit `--color` or config override could supersede it (`https://no-color.org/`, lines 68-75; `cmd/clnkr/main.go:496-497`).
+- Should monochrome mode use reverse/underline/bold for the input cursor line, warnings, success/error lines, and new-content badge after color subtraction? Those are the surfaces where current code still depends most on visual contrast (`cmd/clnkr/styles.go:67-96`; `cmd/clnkr/chat.go:90-145`; `cmd/clnkr/input.go:29-45`).
+- Is the desired markdown no-color output closer to upstream ASCII/NoTTY, or to a custom repo-specific monochrome style that preserves some retro structure without ANSI colors? The brief requires an intentional monochrome pass, but it does not require preserving every existing retro accent (`/home/bcosgrove/tmp/tui-multiagent-coord/clnkr-03-no-color-monochrome.md:13-21`).
+- Verification should assert output behavior, not only builder-path selection. In `NO_COLOR` mode, tests should reject color-setting escape sequences while allowing intentional non-color emphasis such as bold, underline, reverse, spacing, prefixes, and ASCII structure (`cmd/clnkr/render_test.go:8-50`; `https://no-color.org/`, lines 7-10).
+
+## Verified facts
+
+- `cmd/clnkr` is a separate Go module and imports `bubbletea`, `bubbles`, `lipgloss/v2`, and `glamour` there (`cmd/clnkr/go.mod:1-15`).
+- `runTUI` hard-codes `defaultStyles(true)` and does not consult `NO_COLOR` (`cmd/clnkr/main.go:496-497`).
+- `defaultStyles` ignores `hasDark` and creates a fully colorized palette for chat, status, and input (`cmd/clnkr/styles.go:56-98`).
+- Chat rendering applies styled pending/success/error/debug/warning lines and a styled “new content” indicator (`cmd/clnkr/chat.go:90-145`; `cmd/clnkr/ui.go:1055-1061`).
+- Status mode text is plain text content rendered through a single `Bar` style; modes include `HELP`, `DIFF`, `REASONING`, `APPROVAL`, `CLARIFY`, `RUNNING`, `SCROLL`, and `INPUT` (`cmd/clnkr/status.go:58-80`; `cmd/clnkr/ui.go:1072-1111`).
+- Markdown rendering uses a shared cached Glamour renderer configured with `WithStyles(retroMarkdownStyle())` and `WithWordWrap(width)` (`cmd/clnkr/render.go:9-24`).
+- `retroMarkdownStyle` overrides ASCII base styles with explicit colors/backgrounds for headings, strong/emphasis, rules, lists, links, inline code, code blocks, and tables (`cmd/clnkr/render.go:42-205`).
+- Lip Gloss `NoColor` exists specifically to remove color styling while leaving style APIs intact (`/home/bcosgrove/go/pkg/mod/charm.land/lipgloss/v2@v2.0.1/color.go:45-60`).
+- Glamour exposes API support for swapping style configs and keeping word wrapping unchanged (`/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/glamour.go:163-195`).
+- Glamour ships ASCII/NoTTY built-ins that can serve as a no-color markdown baseline (`/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/styles/styles.go:29-90,662-670`).
+- `go test ./...` passes in `cmd/clnkr` in this worktree (`cmd/clnkr`: local command run on 2026-04-23, output `ok github.com/clnkr-ai/clnkr/cmd/clnkr 0.954s`).
+
+## Inference
+
+- Most defensible starting point is a narrow version of approach 1: explicit `NO_COLOR` plumbing plus the smallest monochrome style changes needed to satisfy the brief. The code already carries semantic text and icons for status and chat states, so the implementation should start with subtraction of color and add non-color emphasis only where rendered output shows a real readability loss (`cmd/clnkr/status.go:58-80`; `cmd/clnkr/chat.go:90-145`; `cmd/clnkr/ui.go:1055-1065`).
+- Tests should check rendered output for the absence of color-setting escapes in `NO_COLOR` mode, while still allowing intentional non-color emphasis. Builder-path tests alone would miss regressions in the actual terminal output.
+- Input cursor color is part of the feature scope because it bypasses Lip Gloss text/background styling and is wired separately through `inputModel` (`cmd/clnkr/styles.go:41,94`; `cmd/clnkr/input.go:44`).
+- Renderer caching needs explicit no-color awareness in code or tests, even for a startup-only feature, because the current package-global renderer is reused until manually cleared (`cmd/clnkr/render.go:9-31`).
+- If the implementation also addresses background detection now, Bubble Tea’s `BackgroundColorMsg` path is the upstream-aligned way to do it, but that is optional for `NO_COLOR` itself (`https://pkg.go.dev/charm.land/lipgloss/v2`, lines 1118-1130 and 1703-1719).
+
+## Citations
+
+- Repo docs: `AGENTS.md`
+- Repo code:
+  - `cmd/clnkr/go.mod:1-15`
+  - `cmd/clnkr/main.go:496-497`
+  - `cmd/clnkr/styles.go:18-103`
+  - `cmd/clnkr/render.go:9-218`
+  - `cmd/clnkr/chat.go:77-298`
+  - `cmd/clnkr/status.go:11-132`
+  - `cmd/clnkr/input.go:18-45`
+  - `cmd/clnkr/ui.go:1036-1111`
+  - `cmd/clnkr/render_test.go:8-50`
+  - `cmd/clnkr/status_test.go:11-127`
+  - `cmd/clnkr/ui_test.go:18-30`
+- Local dependency source:
+  - `/home/bcosgrove/go/pkg/mod/charm.land/lipgloss/v2@v2.0.1/color.go:45-60`
+  - `/home/bcosgrove/go/pkg/mod/charm.land/lipgloss/v2@v2.0.1/set.go:272-280`
+  - `/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/glamour.go:163-195`
+  - `/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/styles/styles.go:29-90`
+  - `/home/bcosgrove/go/pkg/mod/github.com/charmbracelet/glamour@v0.10.0/styles/styles.go:662-670`
+- External docs:
+  - `https://no-color.org/` lines 7-10
+  - `https://pkg.go.dev/charm.land/lipgloss/v2` lines 1110-1144, 1703-1719, 2327-2340
+  - `https://pkg.go.dev/github.com/charmbracelet/glamour` lines 435-461
+  - `https://pkg.go.dev/github.com/charmbracelet/glamour/styles` lines 1339-1348


### PR DESCRIPTION
## Summary

`cmd/clnkr` now honors `NO_COLOR`.

This change adds a startup no-color path for the TUI, switches markdown rendering onto a monochrome style, and keeps the main state changes readable without ANSI color. It also fixes renderer reuse so color and no-color renders do not bleed into each other in the same process.

## What changed

- add `NO_COLOR` detection at TUI startup
- keep existing color styles intact, add a separate monochrome startup style path
- make markdown rendering mode-aware and cache by width plus color mode
- thread no-color markdown rendering through chat and reasoning views
- add tests for startup style selection, monochrome markdown, status and composed TUI output, neutral cursor color, and warning rendering

## Verification

- `cd cmd/clnkr && go test ./...`
- `make _fmt`
- `make check`
