### PR TITLE
Dummy PR to verify thoth critical gate

### DIFF
--- a/thoth_critical_dummy_test.go
+++ b/thoth_critical_dummy_test.go
@@ -1,0 +1,560 @@
+package clnkr
+
+import "testing"
+
+func TestThothCriticalDummy(t *testing.T) {
+	value := 42
+	if value == 0 {
+		t.Log(value)
+	}
+	if value == 1 {
+		t.Log(value)
+	}
+	if value == 2 {
+		t.Log(value)
+	}
+	if value == 3 {
+		t.Log(value)
+	}
+	if value == 4 {
+		t.Log(value)
+	}
+	if value == 5 {
+		t.Log(value)
+	}
+	if value == 6 {
+		t.Log(value)
+	}
+	if value == 7 {
+		t.Log(value)
+	}
+	if value == 8 {
+		t.Log(value)
+	}
+	if value == 9 {
+		t.Log(value)
+	}
+	if value == 10 {
+		t.Log(value)
+	}
+	if value == 11 {
+		t.Log(value)
+	}
+	if value == 12 {
+		t.Log(value)
+	}
+	if value == 13 {
+		t.Log(value)
+	}
+	if value == 14 {
+		t.Log(value)
+	}
+	if value == 15 {
+		t.Log(value)
+	}
+	if value == 16 {
+		t.Log(value)
+	}
+	if value == 17 {
+		t.Log(value)
+	}
+	if value == 18 {
+		t.Log(value)
+	}
+	if value == 19 {
+		t.Log(value)
+	}
+	if value == 20 {
+		t.Log(value)
+	}
+	if value == 21 {
+		t.Log(value)
+	}
+	if value == 22 {
+		t.Log(value)
+	}
+	if value == 23 {
+		t.Log(value)
+	}
+	if value == 24 {
+		t.Log(value)
+	}
+	if value == 25 {
+		t.Log(value)
+	}
+	if value == 26 {
+		t.Log(value)
+	}
+	if value == 27 {
+		t.Log(value)
+	}
+	if value == 28 {
+		t.Log(value)
+	}
+	if value == 29 {
+		t.Log(value)
+	}
+	if value == 30 {
+		t.Log(value)
+	}
+	if value == 31 {
+		t.Log(value)
+	}
+	if value == 32 {
+		t.Log(value)
+	}
+	if value == 33 {
+		t.Log(value)
+	}
+	if value == 34 {
+		t.Log(value)
+	}
+	if value == 35 {
+		t.Log(value)
+	}
+	if value == 36 {
+		t.Log(value)
+	}
+	if value == 37 {
+		t.Log(value)
+	}
+	if value == 38 {
+		t.Log(value)
+	}
+	if value == 39 {
+		t.Log(value)
+	}
+	if value == 40 {
+		t.Log(value)
+	}
+	if value == 41 {
+		t.Log(value)
+	}
+	if value == 42 {
+		t.Log(value)
+	}
+	if value == 43 {
+		t.Log(value)
+	}
+	if value == 44 {
+		t.Log(value)
+	}
+	if value == 45 {
+		t.Log(value)
+	}
+	if value == 46 {
+		t.Log(value)
+	}
+	if value == 47 {
+		t.Log(value)
+	}
+	if value == 48 {
+		t.Log(value)
+	}
+	if value == 49 {
+		t.Log(value)
+	}
+	if value == 50 {
+		t.Log(value)
+	}
+	if value == 51 {
+		t.Log(value)
+	}
+	if value == 52 {
+		t.Log(value)
+	}
+	if value == 53 {
+		t.Log(value)
+	}
+	if value == 54 {
+		t.Log(value)
+	}
+	if value == 55 {
+		t.Log(value)
+	}
+	if value == 56 {
+		t.Log(value)
+	}
+	if value == 57 {
+		t.Log(value)
+	}
+	if value == 58 {
+		t.Log(value)
+	}
+	if value == 59 {
+		t.Log(value)
+	}
+	if value == 60 {
+		t.Log(value)
+	}
+	if value == 61 {
+		t.Log(value)
+	}
+	if value == 62 {
+		t.Log(value)
+	}
+	if value == 63 {
+		t.Log(value)
+	}
+	if value == 64 {
+		t.Log(value)
+	}
+	if value == 65 {
+		t.Log(value)
+	}
+	if value == 66 {
+		t.Log(value)
+	}
+	if value == 67 {
+		t.Log(value)
+	}
+	if value == 68 {
+		t.Log(value)
+	}
+	if value == 69 {
+		t.Log(value)
+	}
+	if value == 70 {
+		t.Log(value)
+	}
+	if value == 71 {
+		t.Log(value)
+	}
+	if value == 72 {
+		t.Log(value)
+	}
+	if value == 73 {
+		t.Log(value)
+	}
+	if value == 74 {
+		t.Log(value)
+	}
+	if value == 75 {
+		t.Log(value)
+	}
+	if value == 76 {
+		t.Log(value)
+	}
+	if value == 77 {
+		t.Log(value)
+	}
+	if value == 78 {
+		t.Log(value)
+	}
+	if value == 79 {
+		t.Log(value)
+	}
+	if value == 80 {
+		t.Log(value)
+	}
+	if value == 81 {
+		t.Log(value)
+	}
+	if value == 82 {
+		t.Log(value)
+	}
+	if value == 83 {
+		t.Log(value)
+	}
+	if value == 84 {
+		t.Log(value)
+	}
+	if value == 85 {
+		t.Log(value)
+	}
+	if value == 86 {
+		t.Log(value)
+	}
+	if value == 87 {
+		t.Log(value)
+	}
+	if value == 88 {
+		t.Log(value)
+	}
+	if value == 89 {
+		t.Log(value)
+	}
+	if value == 90 {
+		t.Log(value)
+	}
+	if value == 91 {
+		t.Log(value)
+	}
+	if value == 92 {
+		t.Log(value)
+	}
+	if value == 93 {
+		t.Log(value)
+	}
+	if value == 94 {
+		t.Log(value)
+	}
+	if value == 95 {
+		t.Log(value)
+	}
+	if value == 96 {
+		t.Log(value)
+	}
+	if value == 97 {
+		t.Log(value)
+	}
+	if value == 98 {
+		t.Log(value)
+	}
+	if value == 99 {
+		t.Log(value)
+	}
+}
+
+func TestThothCriticalDummyNested(t *testing.T) {
+	for a := 0; a < 1; a++ {
+		for b := 0; b < 1; b++ {
+			for c := 0; c < 1; c++ {
+				for d := 0; d < 1; d++ {
+					for e := 0; e < 1; e++ {
+						for f := 0; f < 1; f++ {
+							for g := 0; g < 1; g++ {
+								for h := 0; h < 1; h++ {
+									for i := 0; i < 1; i++ {
+										for j := 0; j < 1; j++ {
+											if a == 0 {
+												if b == 0 {
+													if c == 0 {
+														if d == 0 {
+															if e == 0 {
+																if f == 0 {
+																	if g == 0 {
+																		if h == 0 {
+																			if i == 0 {
+																				if j == 0 {
+																					t.Log(a, b, c, d, e, f, g, h, i, j)
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func thothCriticalDummyHelper(
+	t *testing.T,
+	alpha int,
+	bravo int,
+	charlie int,
+	delta int,
+	echo int,
+	foxtrot int,
+	golf int,
+	hotel int,
+	india int,
+	juliet int,
+	kilo int,
+	lima int,
+	mike int,
+	november int,
+	oscar int,
+	papa int,
+	quebec int,
+	romeo int,
+	sierra int,
+	tango int,
+	uniform int,
+	victor int,
+	whiskey int,
+	xray int,
+	yankee int,
+	zulu int,
+) int {
+	total := alpha + bravo + charlie + delta + echo + foxtrot + golf + hotel + india + juliet + kilo + lima + mike
+	total += november + oscar + papa + quebec + romeo + sierra + tango + uniform + victor + whiskey + xray + yankee + zulu
+	if alpha == 0 {
+		total += alpha
+	}
+	if bravo == 1 {
+		total += bravo
+	}
+	if charlie == 2 {
+		total += charlie
+	}
+	if delta == 3 {
+		total += delta
+	}
+	if echo == 4 {
+		total += echo
+	}
+	if foxtrot == 5 {
+		total += foxtrot
+	}
+	if golf == 6 {
+		total += golf
+	}
+	if hotel == 7 {
+		total += hotel
+	}
+	if india == 8 {
+		total += india
+	}
+	if juliet == 9 {
+		total += juliet
+	}
+	if kilo == 10 {
+		total += kilo
+	}
+	if lima == 11 {
+		total += lima
+	}
+	if mike == 12 {
+		total += mike
+	}
+	if november == 13 {
+		total += november
+	}
+	if oscar == 14 {
+		total += oscar
+	}
+	if papa == 15 {
+		total += papa
+	}
+	if quebec == 16 {
+		total += quebec
+	}
+	if romeo == 17 {
+		total += romeo
+	}
+	if sierra == 18 {
+		total += sierra
+	}
+	if tango == 19 {
+		total += tango
+	}
+	if uniform == 20 {
+		total += uniform
+	}
+	if victor == 21 {
+		total += victor
+	}
+	if whiskey == 22 {
+		total += whiskey
+	}
+	if xray == 23 {
+		total += xray
+	}
+	if yankee == 24 {
+		total += yankee
+	}
+	if zulu == 25 {
+		total += zulu
+	}
+	if total == 0 {
+		t.Log(alpha)
+	}
+	if total == 1 {
+		t.Log(bravo)
+	}
+	if total == 2 {
+		t.Log(charlie)
+	}
+	if total == 3 {
+		t.Log(delta)
+	}
+	if total == 4 {
+		t.Log(echo)
+	}
+	if total == 5 {
+		t.Log(foxtrot)
+	}
+	if total == 6 {
+		t.Log(golf)
+	}
+	if total == 7 {
+		t.Log(hotel)
+	}
+	if total == 8 {
+		t.Log(india)
+	}
+	if total == 9 {
+		t.Log(juliet)
+	}
+	if total == 10 {
+		t.Log(kilo)
+	}
+	if total == 11 {
+		t.Log(lima)
+	}
+	if total == 12 {
+		t.Log(mike)
+	}
+	if total == 13 {
+		t.Log(november)
+	}
+	if total == 14 {
+		t.Log(oscar)
+	}
+	if total == 15 {
+		t.Log(papa)
+	}
+	if total == 16 {
+		t.Log(quebec)
+	}
+	if total == 17 {
+		t.Log(romeo)
+	}
+	if total == 18 {
+		t.Log(sierra)
+	}
+	if total == 19 {
+		t.Log(tango)
+	}
+	if total == 20 {
+		t.Log(uniform)
+	}
+	if total == 21 {
+		t.Log(victor)
+	}
+	if total == 22 {
+		t.Log(whiskey)
+	}
+	if total == 23 {
+		t.Log(xray)
+	}
+	if total == 24 {
+		t.Log(yankee)
+	}
+	if total == 25 {
+		t.Log(zulu)
+	}
+	for a := 0; a < 1; a++ {
+		for b := 0; b < 1; b++ {
+			for c := 0; c < 1; c++ {
+				for d := 0; d < 1; d++ {
+					for e := 0; e < 1; e++ {
+						if a == b {
+							if b == c {
+								if c == d {
+									if d == e {
+										t.Log(a, b, c, d, e)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return total
+}


### PR DESCRIPTION
This PR is intentionally bad. It adds a synthetic Go test file that compiles and passes normal Go tests, but trips the thoth critical gate.\n\nExpected result:\n- regular Go tests pass\n- CI guardrails job fails at `make thoth-critical-check`\n- failure names `thoth_critical_dummy_test.go` with risk >= 0.650\n\nDo not merge.